### PR TITLE
Removed type hints

### DIFF
--- a/PythonAPI/controllers/associate_controller.py
+++ b/PythonAPI/controllers/associate_controller.py
@@ -8,7 +8,7 @@ def route(app):
 
     # Get associate by id endpoint
     @app.route("/associate/<associate_id>", methods=['GET'])
-    def get_associate_id(associate_id: int):
+    def get_associate_id(associate_id):
         try:
             batch = AssociateServices.get_associated_byID(int(associate_id))
             return jsonify(batch.json()), 200

--- a/PythonAPI/daos/batch_dao.py
+++ b/PythonAPI/daos/batch_dao.py
@@ -6,9 +6,9 @@ from models.batch import Batch
 class BatchDAO(ABC):
 
     @abstractmethod
-    def get_all_batches_by_year(self, year: int) -> list[Batch]:
+    def get_all_batches_by_year(self, year):
         pass
 
     @abstractmethod
-    def get_batch_by_id(self, batch_id: int) -> Batch:
+    def get_batch_by_id(self, batch_id):
         pass

--- a/PythonAPI/daos/daos_impl/batch_dao_impl.py
+++ b/PythonAPI/daos/daos_impl/batch_dao_impl.py
@@ -6,7 +6,7 @@ from utils.db_connection import DbConn
 
 class BatchDAOImpl(BatchDAO):
 
-    def get_batch_by_id(self, batch_id: int) -> Batch:
+    def get_batch_by_id(self, batch_id):
         """Takes in an id for a batch record and returns a Batch object"""
         sql = "SELECT * FROM batches where id=%s"
         records = DbConn.make_connect(sql, [batch_id])
@@ -17,7 +17,7 @@ class BatchDAOImpl(BatchDAO):
         else:
             raise ResourceNotFound("No batch could be found with the given id")
 
-    def get_all_batches_by_year(self, year: int) -> list[Batch]:
+    def get_all_batches_by_year(self, year):
         """Takes in a year and returns all the batches currently in progress for that year"""
         sql = "SELECT * FROM batches WHERE date_part('year', batches.start_date) = %s "
         records = DbConn.make_connect(sql, [year])

--- a/PythonAPI/daos/daos_impl/trainer_dao_impl.py
+++ b/PythonAPI/daos/daos_impl/trainer_dao_impl.py
@@ -1,10 +1,8 @@
-
 from daos.trainer_dao import TrainerDAO
 from exceptions.resource_not_found import ResourceNotFound
 from models.batch import Batch
 from models.trainer import Trainer
 from utils.db_connection import DbConn
-
 
 
 class TrainerDAOImpl(TrainerDAO):
@@ -22,7 +20,7 @@ class TrainerDAOImpl(TrainerDAO):
         sql = "select t.id, t.first_name, t.last_name, t.email " \
               "from trainers as t left join trainer_batches tb " \
               "on id = trainer_id where batch_id = %s"
-        records = DbConn.make_connect(sql, [ batch_id])
+        records = DbConn.make_connect(sql, [batch_id])
         trainers = []
         for record in records:
             trainers.append(Trainer(id=record[0], first_name=record[1], last_name=record[2], email=record[3]))
@@ -36,5 +34,3 @@ class TrainerDAOImpl(TrainerDAO):
             return Trainer(id=record[0], first_name=record[1], last_name=record[2], email=record[3])
         else:
             raise ResourceNotFound("No trainer exists with those credentials")
-
-

--- a/PythonAPI/models/batch.py
+++ b/PythonAPI/models/batch.py
@@ -8,18 +8,18 @@ from models.decodable import Decodable
 class Batch(Decodable):
 
     def __init__(self,
-                 name: str,
-                 training_track: str,
-                 start_date: date,
-                 end_date: date,
-                 id: int = -1):
+                 name,
+                 training_track,
+                 start_date,
+                 end_date,
+                 id = -1):
         self.id = id
         self.name = name
         self.training_track = training_track
         self.start_date = start_date
         self.end_date = end_date
 
-    def json(self) -> dict:
+    def json(self):
         return {
             'id': self.id,
             'startDate': self.start_date,
@@ -40,11 +40,11 @@ class Batch(Decodable):
         batch.training_track = json["trainingTrack"]
         return batch
 
-    def current_week(self) -> int:
+    def current_week(self):
         """Returns the current week of training(today - start_date)"""
         return floor(abs((datetime.now().date() - self.start_date).days / 7))
 
-    def total_weeks(self) -> int:
+    def total_weeks(self):
         """Returns the total weeks of training(end_date - start_date)"""
         return floor(abs((self.end_date - self.start_date).days / 7))
 

--- a/PythonAPI/services/batch_services.py
+++ b/PythonAPI/services/batch_services.py
@@ -7,9 +7,9 @@ from models.batch import Batch
 class BatchServices:
 
     @classmethod
-    def get_batch_by_id(cls, batch_id: int) -> Batch:
+    def get_batch_by_id(cls, batch_id):
         return BatchDAOImpl().get_batch_by_id(batch_id)
 
     @classmethod
-    def get_all_batches_by_year(cls, year: int) -> list[Batch]:
+    def get_all_batches_by_year(cls, year):
         return BatchDAOImpl().get_all_batches_by_year(year)

--- a/PythonAPI/utils/connection_generator.py
+++ b/PythonAPI/utils/connection_generator.py
@@ -4,7 +4,7 @@ from configparser import ConfigParser
 class ConnectionGenerator:
 
     @staticmethod
-    def load_conn(database_file: str = "conn_cred.ini", section: str = 'postgresql') -> dict[str, str]:
+    def load_conn(database_file = "conn_cred.ini", section = 'postgresql'):
         """Tries to load connection files, creates one if none exist\n
             Note: Tests need there own ini file. I don't know why"""
         # Checks if file exists and creates one if it does not

--- a/PythonAPI/utils/db_connection.py
+++ b/PythonAPI/utils/db_connection.py
@@ -7,7 +7,7 @@ from utils.connection_generator import ConnectionGenerator
 class DbConn:
 
     @staticmethod
-    def make_connect(query: str = None, values: list = None) -> list:
+    def make_connect(query = None, values = None):
         """Connects to the database and executes a query, returns a list of records"""
         connection = None
         cursor = connection

--- a/PythonAPI/utils/json_tool.py
+++ b/PythonAPI/utils/json_tool.py
@@ -4,10 +4,9 @@ from flask import jsonify, Response
 
 from exceptions.not_serializable import NotSerializableError
 from models.associate import Associate
-from models.decodable import Decodable
 
 
-def convert_list_to_json(items: list[Decodable]) -> list[str]:
+def convert_list_to_json(items):
     """Pass in a Decodable object and recieve a dictionary ready to be jsonified"""
     json_list = []
     try:


### PR DESCRIPTION
Not using type hints seems easier than trying to update python on an EC2 that we don't have direct access to. 